### PR TITLE
add use of "entries" for "files" in tar

### DIFF
--- a/layer.md
+++ b/layer.md
@@ -23,7 +23,7 @@ Removals are represented using "[whiteout](#whiteouts)" file entries (See [Repre
 
 ### File Types
 
-Throughout this document section, the use of word "files" includes:
+Throughout this document section, the use of word "files" or "entries" includes:
 
 * regular files
 * directories


### PR DESCRIPTION
This is a pass at explaining the concept of opaque files and their role in the specification. Provides recommendations that implementations should generate explicit format, but accept opaques.

cc @vbatts @runcom @philips 

Closes #144

Signed-off-by: Stephen J Day stephen.day@docker.com
